### PR TITLE
Register primitives blocks added to system.v

### DIFF
--- a/build-data/vlib/system.v
+++ b/build-data/vlib/system.v
@@ -16,3 +16,181 @@ module SB_IO (
 	parameter IO_STANDARD = "SB_LVCMOS";
 
 endmodule
+
+module SB_DFF (
+        input C,
+        input D,
+        output Q
+);
+
+endmodule
+
+module SB_DFFE (
+        input C,
+        input D,
+	input E,
+        output Q
+);
+
+endmodule
+
+module SB_DFFSR (
+        input C,
+        input D,
+	input R,
+        output Q
+);
+
+endmodule
+
+module SB_DFFR (
+        input C,
+        input D,
+	input R,
+        output Q
+);
+
+endmodule
+
+module SB_DFFSS (
+        input C,
+        input D,
+	input S,
+        output Q
+);
+
+endmodule
+
+module SB_DFFS (
+        input C,
+        input D,
+	input S,
+        output Q
+);
+
+endmodule
+
+module SB_DFFESR (
+        input C,
+        input D,
+	input R,
+	input E,
+        output Q
+);
+
+endmodule
+
+module SB_DFFER (
+	input C,
+	input D,
+	input R,
+	input E,
+	output Q
+);
+
+module SB_DFFESS (
+	input C,
+	input D,
+	input E,
+	input S,
+	output Q
+);
+
+module SB_DFFES (
+	input C,
+	input D,
+	input E,
+	input S,
+	output Q
+);
+
+module SB_DFFN (
+	input C,
+	input D,
+	output Q
+);
+
+module SB_DFFNE (
+	input C,
+	input D,
+	input E,
+	output Q
+);
+
+module SB_DFFNSR (
+	input C,
+	input D,
+	input R,
+	output Q
+);
+
+module SB_DFFNR (
+	input C,
+	input D,
+	input R,
+	output Q
+);
+
+module SB_DFFNSS (
+	input C,
+	input D,
+	input S,
+	output Q
+);
+
+module SB_DFFNS (
+	input C,
+	input D,
+	input S,
+	output Q
+);
+
+module SB_DFFNESR (
+	input C,
+	input D,
+	input E,
+	input R,
+	output Q
+);
+
+module SB_DFFNER (
+	input C,
+	input D,
+	input E,
+	input R,
+	output Q
+);
+
+module SB_DFFNESS (
+	input C,
+	input D,
+	input E,
+	input S,
+	output Q
+);
+
+module SB_DFFNES (
+	input C,
+	input D,
+	input E,
+	input S,
+	output Q
+);
+
+module SB_CARRY (
+	input I0,
+	input I1,
+	input CI,
+	output CO,
+);
+
+module SB_LUT4 (
+        input I0,
+        input I1,
+        input I2,
+        input I3,
+        output O
+);
+
+endmodule
+


### PR DESCRIPTION
Register primitives blocks added to system.v file, based on the SBTICETechnologyLibrary201602 document available [here](http://latticesemi.com/view_document?document_id=51555).
